### PR TITLE
add dependency byte-buddy-dep

### DIFF
--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -167,6 +167,12 @@
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-server</artifactId>
         </dependency>
+	    
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-dep</artifactId>
+            <version>RELEASE</version>
+        </dependency> 
     </dependencies>
 
     <build>


### PR DESCRIPTION
due to error

12:20:20.845 [main] WARN  o.s.b.w.s.c.AnnotationConfigServletWebServerApplicationContext - Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]: Invocation of init method failed; nested exception is java.lang.NoClassDefFoundError: net/bytebuddy/matcher/ElementMatchers

so this link will help
https://stackoverflow.com/questions/53306613/springboot-2-1-0-throws-classnotfoundexception-when-trying-to-integrate-database